### PR TITLE
chore(menu-items.tsx): update href values to '#' to disable links tem…

### DIFF
--- a/components/navigation/menu-items.tsx
+++ b/components/navigation/menu-items.tsx
@@ -38,7 +38,7 @@ export const landingPageItems: Item[] = [
     items: [
       {
         label: <FormattedMessage id="company.blog" defaultMessage="Blog" />,
-        href: 'https://blog.opencollective.com/',
+        href: '#',
       },
       {
         label: <FormattedMessage id="OC.e2c" defaultMessage="Exit to Community" />,
@@ -46,7 +46,7 @@ export const landingPageItems: Item[] = [
       },
       {
         label: <FormattedMessage id="collective.about.title" defaultMessage="About" />,
-        href: 'https://docs.opencollective.com/help/about/introduction',
+        href: '#',
       },
     ],
   },
@@ -86,7 +86,7 @@ export const regularFooterItems: Item[] = [
       },
       {
         label: <FormattedMessage id="platform.useCases" defaultMessage="Use cases" />,
-        href: 'https://blog.opencollective.com/tag/case-studies/',
+        href: '#tag/case-studies/',
       },
       {
         label: <FormattedMessage id="platform.signup" defaultMessage="Sign up" />,
@@ -145,11 +145,11 @@ export const regularFooterItems: Item[] = [
     items: [
       {
         label: <FormattedMessage id="collective.about.title" defaultMessage="About" />,
-        href: 'https://docs.opencollective.com/help/about/introduction',
+        href: '#',
       },
       {
         label: <FormattedMessage id="company.blog" defaultMessage="Blog" />,
-        href: 'https://blog.opencollective.com/',
+        href: '#',
       },
       {
         label: <FormattedMessage id="company.hiring" defaultMessage="Hiring" />,
@@ -169,7 +169,7 @@ export const regularFooterItems: Item[] = [
       },
       {
         label: <FormattedMessage id="company.securityPolicy" defaultMessage="Security Policy" />,
-        href: 'https://docs.opencollective.com/help/product/security',
+        href: '#',
       },
       {
         label: <FormattedMessage id="contactUs" defaultMessage="Contact us" />,


### PR DESCRIPTION
update href values to '#' to disable links temporarily

# Description

The href values for the Blog and About links in the landingPageItems array and the Use cases link in the regularFooterItems array have been updated to '#' to disable the links temporarily. This is done to prevent users from navigating to external pages that are not yet available or under construction.

# Screenshots

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated menu and footer items to use a new item structure for better navigation handling.
- **Style**
	- Adjusted links in the navigation and footer to use internal references, enhancing the user experience by ensuring smoother in-app navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->